### PR TITLE
Simple authentication added

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
     implementation('org.springframework.boot:spring-boot-starter-data-jpa')
     implementation('org.springframework.boot:spring-boot-starter-web')
+    implementation('org.springframework.boot:spring-boot-starter-security')
     implementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.5.2'
     runtimeOnly('com.h2database:h2')

--- a/src/main/java/com/kodilla/ecommercee/security/ShopSecurityConfiguration.java
+++ b/src/main/java/com/kodilla/ecommercee/security/ShopSecurityConfiguration.java
@@ -1,0 +1,22 @@
+package com.kodilla.ecommercee.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+public class ShopSecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+                .mvcMatchers(HttpMethod.GET, "/v1/order/**", "/v1/cart/**", "/v1/user/**", "/v1/group/**", "/v1/product/**").permitAll()
+                .anyRequest().authenticated()
+        .and()
+                .httpBasic()
+        .and()
+                .csrf().disable();
+    }
+
+}


### PR DESCRIPTION
Siema, 
ostatnia rzecz jaką dorobiłem rzutem na taśmę przed zakończeniem projektu to punkt 6-ty w wymaganiach odnośnie autoryzacji. Okazało się to nie jest aż taki ciężkie jak mi się wydawało i dlatego to dorzucam.

Teraz jak chcemy dostać się do endpoint’ów modyfikujących dane, tj. wszystkich innych niż GET to w Postmanie wybieramy zakładkę: 
Auth -> Basic Auth 
Username: user    
Password: wyświetli się u każdego w logach Springa

Endpoint’y GET można używać bez hasła. 

Wiadomo ze to bardzo proste rozwiązanie bo nie sprawdzamy faktycznych userow po haśle, ani nie robimy żadnej autoryzacji po roli user/admin, ale może to lepsze to niż nic:) Jeśli myślicie jednak ze to w takiej formie nie ma sensu (bo w sumie nie mamy tu polaczenia z DB userow i ich haseł itd itp) to tez piszcie to nie będziemy w ogóle mergowac, nie ma problemu:)

![image](https://user-images.githubusercontent.com/73773432/115988958-26e66480-a5bc-11eb-80af-44510e2a27f0.png)

